### PR TITLE
Add backoff and retry when a request is rate limited

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ script:
   - set -o pipefail
   - xcodebuild -version
   - xcodebuild -showsdks
-  - xcodebuild -project "DuoAPISwift.xcodeproj" -scheme "DuoAPISwift" -sdk "macosx10.12" build test | xcpretty
+  - xcodebuild -project "DuoAPISwift.xcodeproj" -scheme "DuoAPISwift" -sdk "macosx10.13" build test | xcpretty
   - pod lib lint

--- a/DuoAPISwift.podspec
+++ b/DuoAPISwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = "DuoAPISwift"
-  spec.version = "2.0.1"
+  spec.version = "2.1.0"
   spec.summary = "Duo Security API client for Swift."
   spec.homepage = "https://github.com/duosecurity/duo_api_swift"
   spec.license = { type: 'BSD', file: 'LICENSE' }

--- a/DuoAPISwift/Client.swift
+++ b/DuoAPISwift/Client.swift
@@ -77,7 +77,7 @@ open class Client: NSObject {
             (data, response, error) in
 
             if error != nil {
-                print("Error making request: \(error?.localizedDescription)")
+                print("Error making request: \(error?.localizedDescription ?? "Couldn't unwrap optional error")")
                 return
             } else if let httpResponse = response as? HTTPURLResponse {
                 completion(data!, httpResponse)

--- a/DuoAPISwift/Info.plist
+++ b/DuoAPISwift/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.1</string>
+	<string>2.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/DuoAPISwiftTests/Info.plist
+++ b/DuoAPISwiftTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.1</string>
+	<string>2.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
If the request is rate limited, this library will now sleep for
a bit and then try again. We use an exponential backoff, so the
request should sleep for 1 second, then 2, then 4, 8, 16, and max
out at 32 seconds.