### PR TITLE
Update signing mechanism to use SHA512 instead of SHA1

### DIFF
--- a/DuoAPISwift/Util.swift
+++ b/DuoAPISwift/Util.swift
@@ -105,7 +105,7 @@ class Util: NSObject {
         let canonicalHeadersString = canonicalize(method, host: host, path: path, params: params, dateString: dateString)
         
         // Sign the canonical string.
-        let signatureHexDigest = canonicalHeadersString.hmac(CryptoAlgorithm.sha1, key: skey)
+        let signatureHexDigest = canonicalHeadersString.hmac(CryptoAlgorithm.sha512, key: skey)
         let authHeader = "\(ikey):\(signatureHexDigest)"
         let base64EncodedAuthHeader = authHeader.toBase64()
         return "Basic \(base64EncodedAuthHeader)"


### PR DESCRIPTION
Duo is migrating off of SHA1 to SHA2 family of hashing algorithms for Authentication API.  

This PR is to update the signing mechanism in duo_api_swift to use SHA512, instead of SHA1. 