### PR TITLE
Disable CI Schedule

### DIFF
--- a/.github/workflows/swift-ci.yml
+++ b/.github/workflows/swift-ci.yml
@@ -7,8 +7,6 @@ on:
   pull_request:
     branches:
       - master
-  schedule:
-   - cron: '0 23 * * 1'
 
 jobs:
    build-and-test:


### PR DESCRIPTION
Scheduled workflows get disabled after a period of inactivity, which also means they don't run on pushes or CI, which is not great.